### PR TITLE
Fixing max scroll position of the thumb

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="Android Studio default JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -15,7 +15,6 @@
             <option value="$PROJECT_DIR$/lib" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk 30
+    compileSdk 32
 
     defaultConfig {
         applicationId "my.nanihadesuka.lazycolumnscrollbar"
         minSdk 21
-        targetSdk 30
+        targetSdk 32
         versionCode 1
         versionName "1.0"
 
@@ -48,15 +48,15 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'com.google.android.material:material:1.6.1'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.3.1'
-    testImplementation 'junit:junit:4.+'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
+    implementation 'androidx.activity:activity-compose:1.4.0'
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "my.nanihadesuka.lazycolumnscrollbar"
         minSdk 21
         targetSdk 32
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/my/nanihadesuka/lazycolumnscrollbar/MainActivity.kt
+++ b/app/src/main/java/my/nanihadesuka/lazycolumnscrollbar/MainActivity.kt
@@ -3,6 +3,8 @@ package my.nanihadesuka.lazycolumnscrollbar
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -13,6 +15,7 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import my.nanihadesuka.compose.LazyColumnScrollbar
@@ -40,15 +43,22 @@ fun ListView() {
     val listData = (0..1000).toList()
     val listState = rememberLazyListState()
 
-    LazyColumnScrollbar(listState) {
-        LazyColumn(state = listState) {
-            items(listData) {
-                Text(
-                    text = "Item $it",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(6.dp)
-                )
+    Box(
+        modifier = Modifier
+            .padding(16.dp)
+            .border(width = 1.dp, MaterialTheme.colors.primary)
+            .padding(1.dp)
+    ) {
+        LazyColumnScrollbar(listState) {
+            LazyColumn(state = listState) {
+                items(listData) {
+                    Text(
+                        text = "Item $it",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/my/nanihadesuka/lazycolumnscrollbar/MainActivity.kt
+++ b/app/src/main/java/my/nanihadesuka/lazycolumnscrollbar/MainActivity.kt
@@ -3,6 +3,7 @@ package my.nanihadesuka.lazycolumnscrollbar
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,11 +11,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -49,7 +53,27 @@ fun ListView() {
             .border(width = 1.dp, MaterialTheme.colors.primary)
             .padding(1.dp)
     ) {
-        LazyColumnScrollbar(listState) {
+        LazyColumnScrollbar(
+            listState,
+            indicatorContent = { index, isThumbSelected ->
+                Text(
+                    text = "i: $index",
+                    Modifier
+                        .clip(
+                            RoundedCornerShape(
+                                topStart = 20.dp,
+                                bottomStart = 20.dp,
+                                bottomEnd = 16.dp
+                            )
+                        )
+                        .background(Color.Green)
+                        .padding(8.dp)
+                        .clip(CircleShape)
+                        .background(if (isThumbSelected) Color.Red else Color.Black)
+                        .padding(12.dp)
+                )
+            }
+        ) {
             LazyColumn(state = listState) {
                 items(listData) {
                     Text(

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.0.1'
+        compose_version = '1.1.1'
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'
+        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 26 07:25:33 CEST 2021
+#Thu Jun 02 02:25:41 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
     implementation 'androidx.activity:activity-compose:1.3.1'
+    implementation "androidx.constraintlayout:constraintlayout-compose:1.0.0-beta02"
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -10,6 +10,8 @@ android {
     defaultConfig {
         minSdk 21
         targetSdk 32
+        versionCode 2
+        versionName "1.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -5,13 +5,11 @@ plugins {
 }
 
 android {
-    compileSdk 30
+    compileSdk 32
 
     defaultConfig {
         minSdk 21
-        targetSdk 30
-        versionCode 1
-        versionName "1.0"
+        targetSdk 32
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -61,16 +59,16 @@ afterEvaluate {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'com.google.android.material:material:1.6.1'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.3.1'
-    implementation "androidx.constraintlayout:constraintlayout-compose:1.0.0-beta02"
-    testImplementation 'junit:junit:4.+'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
+    implementation 'androidx.activity:activity-compose:1.4.0'
+    implementation "androidx.constraintlayout:constraintlayout-compose:1.1.0-alpha02"
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"

--- a/lib/src/main/java/my/nanihadesuka/compose/LazyColumnScrollbar.kt
+++ b/lib/src/main/java/my/nanihadesuka/compose/LazyColumnScrollbar.kt
@@ -160,7 +160,7 @@ fun LazyColumnScrollbar(
 			Box(
 				Modifier
 					.align(Alignment.TopEnd)
-					.graphicsLayer { translationY = constraints.maxHeight.toFloat() * normalizedOffsetPosition() }
+					.graphicsLayer { translationY = (constraints.maxHeight.toFloat() * (1 - normalizedThumbSize())) * normalizedOffsetPosition() }
 					.padding(horizontal = padding)
 					.width(thickness)
 					.clip(thumbShape)

--- a/lib/src/main/java/my/nanihadesuka/compose/LazyColumnScrollbar.kt
+++ b/lib/src/main/java/my/nanihadesuka/compose/LazyColumnScrollbar.kt
@@ -1,6 +1,5 @@
 package my.nanihadesuka.compose
 
-import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -9,7 +8,6 @@ import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyListItemInfo
-import androidx.compose.foundation.lazy.LazyListLayoutInfo
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.*
@@ -44,8 +42,7 @@ fun LazyColumnScrollbar(
 	thumbSelectedColor: Color = Color(0xFF5281CA),
 	thumbShape: Shape = CircleShape,
 	content: @Composable () -> Unit
-)
-{
+) {
 	Box {
 		content()
 		LazyColumnScrollbar(
@@ -79,114 +76,156 @@ fun LazyColumnScrollbar(
 	thumbColor: Color = Color(0xFF2A59B6),
 	thumbSelectedColor: Color = Color(0xFF5281CA),
 	thumbShape: Shape = CircleShape
-)
-{
+) {
 	val coroutineScope = rememberCoroutineScope()
-	
-	var isSelected by remember { mutableStateOf(false) }
-	
-	var dragOffset by remember { mutableStateOf(0f) }
-	
-	fun LazyListItemInfo.fractionHiddenTop() = -offset.toFloat() / size.toFloat()
-	fun LazyListItemInfo.fractionVisibleBottom(viewportEndOffset: Int) = (viewportEndOffset - offset).toFloat() / size.toFloat()
-	
-	fun normalizedThumbSize() = listState.layoutInfo.let {
-		if (it.totalItemsCount == 0) return@let 0f
-		val firstPartial = it.visibleItemsInfo.first().fractionHiddenTop()
-		val lastPartial = 1f - it.visibleItemsInfo.last().fractionVisibleBottom(it.viewportEndOffset)
-		val realVisibleSize = it.visibleItemsInfo.size.toFloat() - firstPartial - lastPartial
-		realVisibleSize / it.totalItemsCount.toFloat()
-	}.coerceAtLeast(thumbMinHeight)
-	
-	fun LazyListLayoutInfo.calcOffset(top:Float): Float {
-		val bottom = visibleItemsInfo.last().run { index.toFloat() + fractionVisibleBottom(viewportEndOffset) } / totalItemsCount.toFloat()
-		val offset = top * (1 - bottom) + bottom * bottom
-		return offset * (1f - normalizedThumbSize())
-	}
-	
-	fun normalizedOffsetPosition() = listState.layoutInfo.let {
-		if (it.totalItemsCount == 0 || it.visibleItemsInfo.isEmpty())
-			return@let 0f
-		
-		val top = it.visibleItemsInfo.first().run { index.toFloat() + fractionHiddenTop() } / it.totalItemsCount.toFloat()
-		it.calcOffset(top)
-	}
-	
 
-	
-	fun setScrollOffset(newOffset: Float)
-	{
-		dragOffset = newOffset.coerceIn(0f, 1f)
-		
-		val exactIndex: Float = listState.layoutInfo.totalItemsCount.toFloat() * dragOffset
+	var isSelected by remember { mutableStateOf(false) }
+
+	var dragOffset by remember { mutableStateOf(0f) }
+
+	fun LazyListItemInfo.fractionHiddenTop() =
+		if (size == 0) 0f else -offset.toFloat() / size.toFloat()
+
+	fun LazyListItemInfo.fractionVisibleBottom(viewportEndOffset: Int) =
+		if (size == 0) 0f else (viewportEndOffset - offset).toFloat() / size.toFloat()
+
+	val normalizedThumbSizeReal by remember {
+		derivedStateOf {
+			listState.layoutInfo.let {
+				if (it.totalItemsCount == 0)
+					return@let 0f
+
+				val firstPartial =
+					it.visibleItemsInfo.first().fractionHiddenTop()
+				val lastPartial =
+					1f - it.visibleItemsInfo.last().fractionVisibleBottom(it.viewportEndOffset)
+				val realVisibleSize =
+					it.visibleItemsInfo.size.toFloat() - firstPartial - lastPartial
+				realVisibleSize / it.totalItemsCount.toFloat()
+			}
+		}
+	}
+
+	val normalizedThumbSize by remember {
+		derivedStateOf {
+			normalizedThumbSizeReal.coerceAtLeast(thumbMinHeight)
+		}
+	}
+
+	fun offsetCorrection(top: Float): Float {
+		if (normalizedThumbSizeReal >= thumbMinHeight)
+			return top
+		val topRealMax = 1f - normalizedThumbSizeReal
+		val topMax = 1f - thumbMinHeight
+		return top * topMax / topRealMax
+	}
+
+	fun offsetCorrectionInverse(top: Float): Float {
+		if (normalizedThumbSizeReal >= thumbMinHeight)
+			return top
+		val topRealMax = 1f - normalizedThumbSizeReal
+		val topMax = 1f - thumbMinHeight
+		return top * topRealMax / topMax
+	}
+
+	val normalizedOffsetPosition by remember {
+		derivedStateOf {
+			listState.layoutInfo.let {
+				if (it.totalItemsCount == 0 || it.visibleItemsInfo.isEmpty())
+					return@let 0f
+
+				val top = it.visibleItemsInfo
+					.first()
+					.run { index.toFloat() + fractionHiddenTop() } / it.totalItemsCount.toFloat()
+				offsetCorrection(top)
+			}
+		}
+	}
+
+	fun setDragOffset(value: Float) {
+		dragOffset = value.coerceIn(0f, 1f - normalizedThumbSize)
+	}
+
+	fun setScrollOffset(newOffset: Float) {
+		setDragOffset(newOffset)
+        val totalItemsCount = listState.layoutInfo.totalItemsCount.toFloat()
+		val exactIndex = offsetCorrectionInverse(totalItemsCount * dragOffset)
 		val index: Int = floor(exactIndex).toInt()
 		val remainder: Float = exactIndex - floor(exactIndex)
-		
+
 		coroutineScope.launch {
 			listState.scrollToItem(index = index, scrollOffset = 0)
-			val offset = listState.layoutInfo.visibleItemsInfo.firstOrNull()?.size?.let { it.toFloat() * remainder }?.toInt() ?: 0
+			val offset = listState.layoutInfo.visibleItemsInfo
+				.firstOrNull()
+				?.size
+				?.let { it.toFloat() * remainder }
+				?.toInt() ?: 0
 			listState.scrollToItem(index = index, scrollOffset = offset)
 		}
 	}
-	
-	val isInAction = listState.isScrollInProgress || isSelected
-	
+
+	val isInAction by remember {
+      derivedStateOf {
+          listState.isScrollInProgress || isSelected
+      }
+    }
+
 	val alpha by animateFloatAsState(
 		targetValue = if (isInAction) 1f else 0f,
-		animationSpec = tween(durationMillis = if (isInAction) 75 else 500, delayMillis = if (isInAction) 0 else 500)
+		animationSpec = tween(
+			durationMillis = if (isInAction) 75 else 500,
+			delayMillis = if (isInAction) 0 else 500
+		)
 	)
-	
+
 	val displacement by animateFloatAsState(
 		targetValue = if (isInAction) 0f else 14f,
-		animationSpec = tween(durationMillis = if (isInAction) 75 else 500, delayMillis = if (isInAction) 0 else 500)
+		animationSpec = tween(
+			durationMillis = if (isInAction) 75 else 500,
+			delayMillis = if (isInAction) 0 else 500
+		)
 	)
-	
+
 	BoxWithConstraints(Modifier.fillMaxWidth()) {
-		
 		val dragState = rememberDraggableState { delta ->
-			setScrollOffset(dragOffset + delta / constraints.maxHeight.toFloat()/(1f -normalizedThumbSize()))
+			setScrollOffset(dragOffset + delta / constraints.maxHeight.toFloat())
 		}
-		
+
 		BoxWithConstraints(
-			Modifier
-				.align(if (rightSide) Alignment.TopEnd else Alignment.TopStart)
-				.alpha(alpha)
-				.fillMaxHeight()
-				.draggable(
-					state = dragState,
-					orientation = Orientation.Vertical,
-					startDragImmediately = true,
-					onDragStarted = { offset ->
-						Log.e(">>>>","$offset")
-						val newOffset = listState.layoutInfo.calcOffset(offset.y / constraints.maxHeight.toFloat())
-						val currentOffset = normalizedOffsetPosition()
-						
-						if (currentOffset < newOffset && newOffset < currentOffset + normalizedThumbSize()) {
-							Log.e(">>>>", "inside")
-							dragOffset = currentOffset
-						} else {
-							Log.e(">>>>","out")
-							setScrollOffset(newOffset)
-						}
-						
-						isSelected = true
-					},
-					onDragStopped = {
-						isSelected = false
-					}
-				)
-				.absoluteOffset(x = if (rightSide) displacement.dp else -displacement.dp)
+            Modifier
+                .align(if (rightSide) Alignment.TopEnd else Alignment.TopStart)
+                .alpha(alpha)
+                .fillMaxHeight()
+                .draggable(
+                    state = dragState,
+                    orientation = Orientation.Vertical,
+                    startDragImmediately = true,
+                    onDragStarted = { offset ->
+                        val newOffset = offset.y / constraints.maxHeight.toFloat()
+                        val currentOffset = normalizedOffsetPosition
+                        if (newOffset in currentOffset..(currentOffset + normalizedThumbSize))
+                            setDragOffset(currentOffset)
+                        else
+                            setScrollOffset(newOffset)
+                        isSelected = true
+                    },
+                    onDragStopped = {
+                        isSelected = false
+                    }
+                )
+                .absoluteOffset(x = if (rightSide) displacement.dp else -displacement.dp)
 		) {
-			
 			Box(
-				Modifier
-					.align(Alignment.TopEnd)
-					.graphicsLayer { translationY = constraints.maxHeight.toFloat() * normalizedOffsetPosition() }
-					.padding(horizontal = padding)
-					.width(thickness)
-					.clip(thumbShape)
-					.background(if (isSelected) thumbSelectedColor else thumbColor)
-					.fillMaxHeight(normalizedThumbSize())
+                Modifier
+                    .align(Alignment.TopEnd)
+                    .graphicsLayer {
+                        translationY = constraints.maxHeight.toFloat() * normalizedOffsetPosition
+                    }
+                    .padding(horizontal = padding)
+                    .width(thickness)
+                    .clip(thumbShape)
+                    .background(if (isSelected) thumbSelectedColor else thumbColor)
+                    .fillMaxHeight(normalizedThumbSize)
 			)
 		}
 	}


### PR DESCRIPTION
The current implementation allows the thumb to scroll past the bottom of the view until the top of the thumb aligns with the bottom of the view. This change will make it so the bottom of the thumb cannot go below the bottom of the view