### PR TITLE
Scroolbar smoothing for stagged grids

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "my.nanihadesuka.lazycolumnscrollbar.sample"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "my.nanihadesuka.lazycolumnscrollbar"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
 		<activity
 			android:name="my.nanihadesuka.lazycolumnscrollbar.MainActivity"
 			android:exported="true"
-			android:label="@string/app_name"
 			android:theme="@style/Theme.LazyColumnScrollbar.NoActionBar"
 			>
 			<intent-filter>

--- a/app/src/main/java/my/nanihadesuka/lazycolumnscrollbar/MainActivity.kt
+++ b/app/src/main/java/my/nanihadesuka/lazycolumnscrollbar/MainActivity.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -518,11 +519,11 @@ fun PopupView(show: Boolean) {
                 tonalElevation = 4.dp
             ) {
                 val selectedTab = rememberSaveable { mutableStateOf(TypeTab.Column) }
-                val listSize = rememberSaveable { mutableStateOf(50) }
+                val listSize = rememberSaveable { mutableIntStateOf(50) }
 
                 Column(modifier = Modifier.padding(16.dp)) {
                     FlowRow {
-                        for (type in TypeTab.values()) {
+                        for (type in TypeTab.entries) {
                             Text(
                                 text = type.name,
                                 modifier = Modifier
@@ -540,13 +541,13 @@ fun PopupView(show: Boolean) {
                     Spacer(modifier = Modifier.height(16.dp))
 
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(text = "List size: ${listSize.value}")
+                        Text(text = "List size: ${listSize.intValue}")
                         Spacer(modifier = Modifier.width(8.dp))
-                        Button(onClick = { if (listSize.value > 0) listSize.value-- }) {
+                        Button(onClick = { if (listSize.intValue > 0) listSize.intValue-- }) {
                             Text("-")
                         }
                         Spacer(modifier = Modifier.width(4.dp))
-                        Button(onClick = { listSize.value++ }) {
+                        Button(onClick = { listSize.intValue++ }) {
                             Text("+")
                         }
                     }
@@ -554,15 +555,15 @@ fun PopupView(show: Boolean) {
                     Spacer(modifier = Modifier.height(16.dp))
 
                     when (selectedTab.value) {
-                        TypeTab.Column -> ColumnView(itemCount = listSize.value)
-                        TypeTab.Row -> RowView(itemCount = listSize.value)
-                        TypeTab.LazyColumn -> LazyColumnView(itemCount = listSize.value)
-                        TypeTab.LazyRow -> LazyRowView(itemCount = listSize.value)
-                        TypeTab.LazyVerticalGrid -> LazyVerticalGridView(itemCount = listSize.value)
-                        TypeTab.LazyHorizontalGrid -> LazyHorizontalGridView(itemCount = listSize.value)
-                        TypeTab.LazyVerticalStaggeredGrid -> LazyVerticalStaggeredGridView(itemCount = listSize.value)
+                        TypeTab.Column -> ColumnView(itemCount = listSize.intValue)
+                        TypeTab.Row -> RowView(itemCount = listSize.intValue)
+                        TypeTab.LazyColumn -> LazyColumnView(itemCount = listSize.intValue)
+                        TypeTab.LazyRow -> LazyRowView(itemCount = listSize.intValue)
+                        TypeTab.LazyVerticalGrid -> LazyVerticalGridView(itemCount = listSize.intValue)
+                        TypeTab.LazyHorizontalGrid -> LazyHorizontalGridView(itemCount = listSize.intValue)
+                        TypeTab.LazyVerticalStaggeredGrid -> LazyVerticalStaggeredGridView(itemCount = listSize.intValue)
                         TypeTab.LazyHorizontalStaggeredGrid -> LazyHorizontalStaggeredGridView(
-                            itemCount = listSize.value
+                            itemCount = listSize.intValue
                         )
 
                         TypeTab.Popup -> {}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
-kotlin = "2.0.20"
-plugin-agp = "8.6.0"
+kotlin = "2.2.20"
+plugin-agp = "8.13.0"
 
-activityCompose = "1.9.2"
+activityCompose = "1.11.0"
 junit = "4.13.2"
-material = "1.12.0"
-robolectric = "4.11.1"
-jetbrains-compose = "1.7.0-beta02"
-compose = "1.7.1"
+material = "1.13.0"
+robolectric = "4.16"
+jetbrains-compose = "1.9.1"
+compose = "1.9.3"
 
 [libraries]
 android-material = { module = "com.google.android.material:material", version.ref = "material" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -10,13 +10,13 @@ plugins {
 }
 
 object MySettings {
-    val versionName: String = "2.2.3"
-    val namespace = "my.nanihadesuka.lazycolumnscrollbar"
+    const val versionName: String = "2.2.6"
+    const val namespace = "my.nanihadesuka.lazycolumnscrollbar"
 }
 
 android {
     namespace = MySettings.namespace
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 21
@@ -43,7 +43,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    @Suppress("UnstableApiUsage")
     testOptions {
         unitTests {
             isIncludeAndroidResources = true

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/ColumnScrollbar.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/ColumnScrollbar.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
@@ -42,6 +45,7 @@ fun InternalColumnScrollbar(
     settings: ScrollbarSettings = ScrollbarSettings.Default,
     indicatorContent: (@Composable (normalizedOffset: Float, isThumbSelected: Boolean) -> Unit)? = null,
     visibleLengthDp: Dp,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) }
 ) {
     val stateController = rememberScrollStateController(
         state = state,
@@ -49,7 +53,8 @@ fun InternalColumnScrollbar(
         thumbMinLength = settings.thumbMinLength,
         thumbMaxLength = settings.thumbMaxLength,
         alwaysShowScrollBar = settings.alwaysShowScrollbar,
-        selectionMode = settings.selectionMode
+        selectionMode = settings.selectionMode,
+        isSelected = isSelected
     )
 
     ElementScrollbar(

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyColumnScrollbar.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyColumnScrollbar.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import my.nanihadesuka.compose.controller.rememberLazyListStateController
 import my.nanihadesuka.compose.generic.ElementScrollbar
@@ -36,6 +39,7 @@ fun InternalLazyColumnScrollbar(
     modifier: Modifier = Modifier,
     settings: ScrollbarSettings = ScrollbarSettings.Default,
     indicatorContent: @Composable() ((index: Int, isThumbSelected: Boolean) -> Unit)? = null,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) }
 ) {
     val controller = rememberLazyListStateController(
         state = state,
@@ -43,6 +47,7 @@ fun InternalLazyColumnScrollbar(
         thumbMaxLength = settings.thumbMaxLength,
         alwaysShowScrollBar = settings.alwaysShowScrollbar,
         selectionMode = settings.selectionMode,
+        isSelected = isSelected
     )
 
     ElementScrollbar(

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyHorizontalGridScrollbar.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyHorizontalGridScrollbar.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import my.nanihadesuka.compose.controller.rememberLazyGridStateController
 import my.nanihadesuka.compose.generic.ElementScrollbar
@@ -14,6 +17,7 @@ fun LazyHorizontalGridScrollbar(
     modifier: Modifier = Modifier,
     settings: ScrollbarSettings = ScrollbarSettings.Default,
     indicatorContent: (@Composable (index: Int, isThumbSelected: Boolean) -> Unit)? = null,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) },
     content: @Composable () -> Unit
 ) {
     if (!settings.enabled) content()
@@ -23,6 +27,7 @@ fun LazyHorizontalGridScrollbar(
             state = state,
             settings = settings,
             indicatorContent = indicatorContent,
+            isSelected = isSelected
         )
     }
 }
@@ -36,6 +41,7 @@ fun InternalLazyHorizontalGridScrollbar(
     modifier: Modifier = Modifier,
     settings: ScrollbarSettings = ScrollbarSettings.Default,
     indicatorContent: (@Composable (index: Int, isThumbSelected: Boolean) -> Unit)? = null,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) }
 ) {
     val controller = rememberLazyGridStateController(
         state = state,
@@ -43,7 +49,8 @@ fun InternalLazyHorizontalGridScrollbar(
         thumbMaxLength = settings.thumbMaxLength,
         alwaysShowScrollBar = settings.alwaysShowScrollbar,
         selectionMode = settings.selectionMode,
-        orientation = Orientation.Horizontal
+        orientation = Orientation.Horizontal,
+        isSelected = isSelected
     )
 
     ElementScrollbar(

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyHorizontalStaggeredGridScrollbar.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyHorizontalStaggeredGridScrollbar.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import my.nanihadesuka.compose.controller.rememberLazyStaggeredGridStateController
 import my.nanihadesuka.compose.generic.ElementScrollbar
@@ -39,6 +42,7 @@ fun InternalLazyHorizontalGridScrollbar(
     reverseLayout: Boolean = false,
     settings: ScrollbarSettings = ScrollbarSettings.Default,
     indicatorContent: (@Composable (index: Int, isThumbSelected: Boolean) -> Unit)? = null,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) }
 ) {
     val controller = rememberLazyStaggeredGridStateController(
         state = state,
@@ -47,7 +51,8 @@ fun InternalLazyHorizontalGridScrollbar(
         thumbMaxLength = settings.thumbMaxLength,
         alwaysShowScrollBar = settings.alwaysShowScrollbar,
         selectionMode = settings.selectionMode,
-        orientation = Orientation.Horizontal
+        orientation = Orientation.Horizontal,
+        isSelected = isSelected
     )
 
     ElementScrollbar(

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyRowScrollbar.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyRowScrollbar.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import my.nanihadesuka.compose.controller.rememberLazyListStateController
 import my.nanihadesuka.compose.generic.ElementScrollbar
@@ -35,6 +38,7 @@ fun InternalLazyRowScrollbar(
     state: LazyListState,
     modifier: Modifier = Modifier,
     settings: ScrollbarSettings = ScrollbarSettings.Default,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) },
     indicatorContent: (@Composable (index: Int, isThumbSelected: Boolean) -> Unit)? = null,
 ) {
     val controller = rememberLazyListStateController(
@@ -43,6 +47,7 @@ fun InternalLazyRowScrollbar(
         thumbMaxLength = settings.thumbMaxLength,
         alwaysShowScrollBar = settings.alwaysShowScrollbar,
         selectionMode = settings.selectionMode,
+        isSelected = isSelected
     )
 
     ElementScrollbar(

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyVerticalGridScrollbar.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyVerticalGridScrollbar.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import my.nanihadesuka.compose.controller.rememberLazyGridStateController
 import my.nanihadesuka.compose.generic.ElementScrollbar
@@ -14,6 +17,7 @@ fun LazyVerticalGridScrollbar(
     modifier: Modifier = Modifier,
     settings: ScrollbarSettings = ScrollbarSettings.Default,
     indicatorContent: (@Composable (index: Int, isThumbSelected: Boolean) -> Unit)? = null,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) },
     content: @Composable () -> Unit
 ) {
     if (!settings.enabled) content()
@@ -23,6 +27,7 @@ fun LazyVerticalGridScrollbar(
             state = state,
             settings = settings,
             indicatorContent = indicatorContent,
+            isSelected = isSelected
         )
     }
 }
@@ -36,6 +41,7 @@ fun InternalLazyVerticalGridScrollbar(
     modifier: Modifier = Modifier,
     settings: ScrollbarSettings = ScrollbarSettings.Default,
     indicatorContent: (@Composable (index: Int, isThumbSelected: Boolean) -> Unit)? = null,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) }
 ) {
     val controller = rememberLazyGridStateController(
         state = state,
@@ -43,7 +49,8 @@ fun InternalLazyVerticalGridScrollbar(
         thumbMaxLength = settings.thumbMaxLength,
         alwaysShowScrollBar = settings.alwaysShowScrollbar,
         selectionMode = settings.selectionMode,
-        orientation = Orientation.Vertical
+        orientation = Orientation.Vertical,
+        isSelected = isSelected
     )
 
     ElementScrollbar(

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyVerticalStaggeredGridScrollbar.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/LazyVerticalStaggeredGridScrollbar.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import my.nanihadesuka.compose.controller.rememberLazyStaggeredGridStateController
 import my.nanihadesuka.compose.generic.ElementScrollbar
@@ -39,6 +42,7 @@ fun InternalLazyVerticalGridScrollbar(
     reverseLayout: Boolean = false,
     settings: ScrollbarSettings = ScrollbarSettings.Default,
     indicatorContent: (@Composable (index: Int, isThumbSelected: Boolean) -> Unit)? = null,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) }
 ) {
     val controller = rememberLazyStaggeredGridStateController(
         state = state,
@@ -47,7 +51,8 @@ fun InternalLazyVerticalGridScrollbar(
         thumbMaxLength = settings.thumbMaxLength,
         alwaysShowScrollBar = settings.alwaysShowScrollbar,
         selectionMode = settings.selectionMode,
-        orientation = Orientation.Vertical
+        orientation = Orientation.Vertical,
+        isSelected = isSelected
     )
 
     ElementScrollbar(

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/RowScrollbar.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/RowScrollbar.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
@@ -41,6 +44,7 @@ fun InternalRowScrollbar(
     settings: ScrollbarSettings = ScrollbarSettings.Default,
     indicatorContent: (@Composable (normalizedOffset: Float, isThumbSelected: Boolean) -> Unit)? = null,
     visibleLengthDp: Dp,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) }
 ) {
     val stateController = rememberScrollStateController(
         state = state,
@@ -49,6 +53,7 @@ fun InternalRowScrollbar(
         thumbMaxLength = settings.thumbMaxLength,
         alwaysShowScrollBar = settings.alwaysShowScrollbar,
         selectionMode = settings.selectionMode,
+        isSelected = isSelected
     )
 
     ElementScrollbar(

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/controller/LazyGridStateController.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/controller/LazyGridStateController.kt
@@ -26,7 +26,8 @@ internal fun rememberLazyGridStateController(
     thumbMaxLength: Float,
     alwaysShowScrollBar: Boolean,
     selectionMode: ScrollbarSelectionMode,
-    orientation: Orientation
+    orientation: Orientation,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) }
 ): LazyGridStateController {
     val coroutineScope = rememberCoroutineScope()
 
@@ -37,9 +38,7 @@ internal fun rememberLazyGridStateController(
     val orientationUpdated = rememberUpdatedState(orientation)
     val reverseLayout = remember { derivedStateOf { state.layoutInfo.reverseLayout } }
 
-    val isSelected = remember { mutableStateOf(false) }
     val dragOffset = remember { mutableFloatStateOf(0f) }
-
 
     val realFirstVisibleItem = remember {
         derivedStateOf {

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/controller/LazyGridStateController.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/controller/LazyGridStateController.kt
@@ -80,7 +80,7 @@ internal fun rememberLazyGridStateController(
 
     fun LazyGridItemInfo.fractionHiddenTop(firstItemOffset: Int): Float {
         return when (orientationUpdated.value) {
-            Orientation.Vertical -> if (size.height == 0) 0f else firstItemOffset / size.width.toFloat()
+            Orientation.Vertical -> if (size.height == 0) 0f else firstItemOffset / size.height.toFloat()
             Orientation.Horizontal -> if (size.width == 0) 0f else firstItemOffset / size.width.toFloat()
         }
     }

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/controller/LazyListStateController.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/controller/LazyListStateController.kt
@@ -24,7 +24,8 @@ internal fun rememberLazyListStateController(
     thumbMinLength: Float,
     thumbMaxLength: Float,
     alwaysShowScrollBar: Boolean,
-    selectionMode: ScrollbarSelectionMode
+    selectionMode: ScrollbarSelectionMode,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) }
 ): LazyListStateController {
     val coroutineScope = rememberCoroutineScope()
 
@@ -34,7 +35,6 @@ internal fun rememberLazyListStateController(
     val selectionModeUpdated = rememberUpdatedState(selectionMode)
     val reverseLayout = remember { derivedStateOf { state.layoutInfo.reverseLayout } }
 
-    val isSelected = remember { mutableStateOf(false) }
     val dragOffset = remember { mutableFloatStateOf(0f) }
 
     val realFirstVisibleItem = remember {

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/controller/LazyStaggeredGridStateController.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/controller/LazyStaggeredGridStateController.kt
@@ -27,7 +27,8 @@ internal fun rememberLazyStaggeredGridStateController(
     thumbMaxLength: Float,
     alwaysShowScrollBar: Boolean,
     selectionMode: ScrollbarSelectionMode,
-    orientation: Orientation
+    orientation: Orientation,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) }
 ): LazyStaggeredGridStateController {
     val coroutineScope = rememberCoroutineScope()
 
@@ -38,7 +39,6 @@ internal fun rememberLazyStaggeredGridStateController(
     val orientationUpdated = rememberUpdatedState(orientation)
     val reverseLayout = remember { derivedStateOf { reverseLayout } }
 
-    val isSelected = remember { mutableStateOf(false) }
     val dragOffset = remember { mutableFloatStateOf(0f) }
 
     val realFirstVisibleItem = remember {

--- a/lib/src/commonMain/kotlin/my/nanihadesuka/compose/controller/ScrollStateController.kt
+++ b/lib/src/commonMain/kotlin/my/nanihadesuka/compose/controller/ScrollStateController.kt
@@ -24,7 +24,8 @@ internal fun rememberScrollStateController(
     thumbMinLength: Float,
     thumbMaxLength: Float,
     alwaysShowScrollBar: Boolean,
-    selectionMode: ScrollbarSelectionMode
+    selectionMode: ScrollbarSelectionMode,
+    isSelected: MutableState<Boolean> = remember { mutableStateOf(false) }
 ): ScrollStateController {
     val coroutineScope = rememberCoroutineScope()
 
@@ -34,7 +35,6 @@ internal fun rememberScrollStateController(
     val alwaysShowScrollBarUpdated = rememberUpdatedState(alwaysShowScrollBar)
     val selectionModeUpdated = rememberUpdatedState(selectionMode)
 
-    val isSelected = remember { mutableStateOf(false) }
     val dragOffset = remember { mutableFloatStateOf(0f) }
 
     val fullLengthDp = with(LocalDensity.current) {


### PR DESCRIPTION
Avoid stretch of thumb calculating its size only when items count changes (it is approximated using the initial visible items value)

Animated thumb offset to avoid jumps during movement